### PR TITLE
Bugfix which replaces non color information

### DIFF
--- a/webserver/static/js/webserver.js
+++ b/webserver/static/js/webserver.js
@@ -283,7 +283,7 @@ HuConApp.appendConsoleLogMessage = function (message, colour) {
         colour = 'black';
     }
 
-    var myRegexp = /\[([a-zA-Z]+)\]/g;
+    var myRegexp = /^\[([a-zA-Z]+)\]/g;
     match = myRegexp.exec(message);
 
     if (match != null && match[1]) {


### PR DESCRIPTION
The colored text function has removed content that should not be removed. It is always necessary that the color information is at the beginning.