### PR TITLE
pin mkdocs-material version

### DIFF
--- a/.github/workflows/build-and-deploy-pages.yml
+++ b/.github/workflows/build-and-deploy-pages.yml
@@ -20,8 +20,11 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y mkdocs
 
+      # We need to pin mkdocs-material to 6.2.8
+      # because starting from 7.0.0 our header layout is broken
+      # (HuCon icon gets huge)
       - name: Prepare python
-        run: pip3 install mkdocs-material pygments markdown pymdown-extensions mkdocs-material-extensions jinja2 --upgrade
+        run: pip3 install mkdocs-material==6.2.8 pygments markdown pymdown-extensions mkdocs-material-extensions jinja2 --upgrade
 
       - name: Build
         run: |


### PR DESCRIPTION
Layout is broken starting with version 7.0.0
so we pin to old version until we get it working at newer version again.